### PR TITLE
fix: link to the original paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cedille is a language developed by [Aaron Stump](http://homepage.divms.uiowa.edu
 ## Typing rules
 
 
-The rules are implemented as described on [this]() paper. Here is a preview:
+The rules are implemented as described on [this](http://homepage.divms.uiowa.edu/~astump/papers/cdle-proofs.pdf) paper. Here is a preview:
 
 ![rules.png](rules.png)
 


### PR DESCRIPTION
the link to the original research was missing.

i believed this was the intended reference: [this](http://homepage.divms.uiowa.edu/~astump/papers/cdle-proofs.pdf)